### PR TITLE
Subscribe to store with decorator

### DIFF
--- a/revived/store.py
+++ b/revived/store.py
@@ -82,6 +82,37 @@ class Store:
 
         return unsubscribe
 
+    def subscriber(self, callback: Callable[[], None]) -> Callable[[], None]:
+        """Decorator function to subscribe a function to store changes.
+
+        The subscribed function will be called every time the internal state of
+        the store changes.
+
+        NOTE: The decorator function will return the function itself. To
+        unsubscribe the callback the user should use the *unsubscribe* function
+        attached into the callback.
+
+        .. code:: python
+
+            # create the store object
+            store = Store(root_reducer)
+
+            # define and subscribe the function
+            @store.subscriber
+            def a_subscriber():
+                # do something!
+                pass
+
+            # unsubscribe the function
+            a_subscriber.unsubscribe()
+
+        :param callback: The callback to be subscribed. :returns: The callback
+        itself.
+        """
+        unsubscribe = self.subscribe(callback)
+        callback.unsubscribe = unsubscribe
+        return callback
+
     def dispatch(self, action: Action) -> None:
         """Dispatches an action.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='revived',
-    version='0.1.0',
+    version='0.1.1',
 
     description='Redux-inspired library in python',
     long_description=long_description,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -61,6 +61,21 @@ def test_store__dispatch__subscriber(dummy_reducer):
     assert called
 
 
+def test_store__dispatch__subscriber_decorator(dummy_reducer):
+    store = Store(dummy_reducer)
+
+    called = False
+
+    @store.subscriber
+    def callback():
+        nonlocal called
+        called = True
+
+    store.dispatch(Action('test'))
+
+    assert called
+
+
 def test_store__unsubscribe(dummy_reducer):
     called = 0
 
@@ -75,5 +90,23 @@ def test_store__unsubscribe(dummy_reducer):
     assert called == 1
 
     unsubscribe()
+    store.dispatch(Action('test'))
+    assert called == 1
+
+
+def test_store__unsubscribe_decorator(dummy_reducer):
+    store = Store(dummy_reducer)
+
+    called = 0
+
+    @store.subscriber
+    def callback():
+        nonlocal called
+        called += 1
+
+    store.dispatch(Action('test'))
+    assert called == 1
+
+    callback.unsubscribe()
     store.dispatch(Action('test'))
     assert called == 1


### PR DESCRIPTION
Addresses #6 

Adds a subscriber method to the Store class. This method is supposed to be used as a decorator for store change callbacks. In this use case it is not possible to return it, **so the unsubscribe function is injected into the callback itself**.

```python
# create the store
store = Store(root_reducer)

# subscribe a callback
@store.subscriber
def a_subscriber():
    # do something!
    pass

# unsubscribe the callback
a_subscriber.unsubscribe()